### PR TITLE
[Hotfix] deploy-dev.yml 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,7 +14,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
           cache: true
           run_install: false
 
@@ -32,11 +31,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-turbo-
 
-      - name: Install dependencies
-        run: pnpm install
-
       - name: Create temporary .env for testing
         run: echo "${{ secrets.DEV_ENV_PROD }}" > .env
+
+      - name: Install dependencies
+        run: HUSKY=0 pnpm install --frozen-lockfile
 
       - name: Build & Test (Turbo)
         run: pnpm turbo run build test lint --cache-dir=".turbo"


### PR DESCRIPTION
## 📌 관련 이슈

#73 

## ✅ PR 체크리스트(최소요구조건)

[ ] 테스트 작성했다.

## ✨ 작업 개요

- [x] pnpm 버전 정보 중복 제거
- [x] CI 과정에서 Husky 제거
- [x] `--frozen-lockfile` 옵션 추가


## 🧹 작업 상세 내용
## 1. `pnpm` 버전 정보 중복 제거

<img width="1708" height="972" alt="image" src="https://github.com/user-attachments/assets/9b1c247f-cb16-4d0d-9ed0-eee48da2c73a" />

**`pnpm/action-setup` 액션과 프로젝트의 `package.json` 사이에 버전 정보가 중복되어 있어서 발생하는 설정 충돌**

`package.json`의 `"packageManager": "pnpm@9.0.0"` 필드를 보고 아래와 같이 version: 9 로 정의한 건데,,, 알고보니  **두 곳 모두에 버전을 적는 행위 자체**가 pnpm의 버전 고정 정책(`corepack` 등)과 충돌한다고 합니다...

```yaml
- name: Install pnpm
        uses: pnpm/action-setup@v4
        with:
          # version: 9  <-- 삭제!!
          cache: true
          run_install: false
```

### 2. CI 과정에서 Husky 제거

<img width="1452" height="652" alt="image" src="https://github.com/user-attachments/assets/00858b2e-5df9-414b-b6f2-b666c3410e81" />

https://typicode.github.io/husky/how-to.html

GitHub Actions(CI)는 코드를 내려받아서 빌드만 하면 되지, 그 안에서 다시 `git commit`이나 `git push`를 할 게 아니기 때문에 **Git Hooks를 심는 과정(install) 자체가 불필요한 자원 낭비이자 잠재적 에러 요인**이 된다고 합니다. 실제로 공식 문서 상에서도 위와 같이 CI 과정에서 허스키를 무시하는 방법을 알려줍니다. 

### 안정성을 위한 `--frozen-lockfile` 옵션 추가

`--frozen-lockfile` 옵션은 CI/CD 환경에서 "절대 락파일(`pnpm-lock.yaml`)을 변경하지 말고, 있는 그대로만 설치해라"라고 명령하는 옵션

<img width="1684" height="1418" alt="image" src="https://github.com/user-attachments/assets/252d6b0f-cf01-439e-aa2a-f91956ce5f0f" />

https://pnpm.io/cli/install

`--frozen-lockfile`은 pnpm에서 CI(지속적 통합) 환경을 위해 설계된 옵션이라고 합니다. 

물론…!실제로 위 사진과 같이 pnpm이 CI 환경을 감지하면 자동으로 true로 설정해주지만, 환경 감지 오류를 방지하고 또 의도 파악을 위해 명시적으로 추가하도록 하겠습니다!

## 🔍 고민 지점

## 💬 기타 참고 사항
