### PR TITLE
[Hotfix] 기록 요약 바텀시트 스크롤 버그 수정

### DIFF
--- a/apps/web/src/features/record/ui/RecordSummaryBottomSheet.tsx
+++ b/apps/web/src/features/record/ui/RecordSummaryBottomSheet.tsx
@@ -42,49 +42,51 @@ export default function RecordSummaryBottomSheet({
 }: RecordSummaryBottomSheetProps) {
   return (
     <BaseBottomSheet isOpen={isOpen} onClose={onClose} height="summary">
-      {/* 고정 영역: 헤더, 위치, 태그, 버튼 */}
-      <div className="shrink-0 px-6 pt-6">
-        <RecordSummaryHeader
-          title={extractTitle(record.text)}
-          date={record.createdAt}
-          onClose={onClose}
-        />
-        <RecordLocationCard location={record.location} />
-        <RecordTagsSection tags={record.tags} />
-      </div>
-
-      {/* 스크롤 영역: 설명 텍스트 */}
-      <div className="flex-1 overflow-y-auto px-6 min-h-0">
-        <div className="pb-6">
-          <p className="text-sm text-gray-600 whitespace-pre-line leading-relaxed">
-            {record.text}
-          </p>
+      <div className="flex flex-col h-full">
+        {/* 고정 영역: 헤더, 위치, 태그, 버튼 */}
+        <div className="shrink-0 px-6 pt-6">
+          <RecordSummaryHeader
+            title={extractTitle(record.text)}
+            date={record.createdAt}
+            onClose={onClose}
+          />
+          <RecordLocationCard location={record.location} />
+          <RecordTagsSection tags={record.tags} />
         </div>
-      </div>
 
-      {/* 고정 영역: 액션 버튼 */}
-      <div className="shrink-0 px-6 pb-6 pt-4 border-t border-transparent">
-        <div className="flex gap-3">
-          {onEdit && (
-            <ActionButton
-              variant="secondary"
-              onClick={onEdit}
-              className="flex-1 flex items-center justify-center gap-2"
-            >
-              <EditIcon className="w-4 h-4" />
-              수정
-            </ActionButton>
-          )}
-          {onDelete && (
-            <ActionButton
-              variant="secondary"
-              onClick={onDelete}
-              className="flex-1 flex items-center justify-center gap-2 bg-red-50 text-red-600 hover:bg-red-100 focus-visible:ring-red-500"
-            >
-              <TrashIcon className="w-4 h-4" />
-              삭제
-            </ActionButton>
-          )}
+        {/* 스크롤 영역: 설명 텍스트 */}
+        <div className="flex-1 overflow-y-auto px-6 min-h-0">
+          <div className="pb-6">
+            <p className="text-sm text-gray-600 whitespace-pre-line leading-relaxed">
+              {record.text}
+            </p>
+          </div>
+        </div>
+
+        {/* 고정 영역: 액션 버튼 */}
+        <div className="shrink-0 px-6 pb-6 pt-4 border-t border-transparent">
+          <div className="flex gap-3">
+            {onEdit && (
+              <ActionButton
+                variant="secondary"
+                onClick={onEdit}
+                className="flex-1 flex items-center justify-center gap-2"
+              >
+                <EditIcon className="w-4 h-4" />
+                수정
+              </ActionButton>
+            )}
+            {onDelete && (
+              <ActionButton
+                variant="secondary"
+                onClick={onDelete}
+                className="flex-1 flex items-center justify-center gap-2 bg-red-50 text-red-600 hover:bg-red-100 focus-visible:ring-red-500"
+              >
+                <TrashIcon className="w-4 h-4" />
+                삭제
+              </ActionButton>
+            )}
+          </div>
         </div>
       </div>
     </BaseBottomSheet>


### PR DESCRIPTION
## 📌 관련 이슈

- #60 

## ✅ PR 체크리스트(최소요구조건)

- [ ] 테스트 작성했다.

## ✨ 작업 개요

- [x] `BaseBottomSheet`
  - [x] 높이 명시적으로 설정
  - [x] 바텀시트 요소(핸들, 자식)에 flex grow/shrink 적용
- [x] 약간의 라인 정리 

## 🧹 작업 상세 내용

### `BaseBottomSheet`

- `summary: 'h-auto min-h-[40vh] max-h-[80vh]'`에서 `h-auto`는 자식 요소 높이의 총합이기 때문에 부모요소의 높이는 상대적으로 결정됩니다.
- 때문에 글자가 많아지면 해당 컨텐츠의 높이만큼 늘어나는 버그가 발생했습니다.
- 높이를 `h-full`로 수정해 기존 `80vh`를 따르도록 했습니다.
- 바텀시트의 핸들과 자식 요소 컨테이너가 바텀시트를 차지하는 비율을 조정하기 위해 flex shrink/grow를 적용했고, 이를 위해 부모 요소에도 flex를 적용했습니다.

## 📸 스크린샷 (선택)

### Before

<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/460d6b54-c595-4921-b811-c37efc05233f" /> <img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/a218e35e-454f-416d-a4c7-68d98c1da8c4" />

글자 수가 많은 경우 요소가 벗어나고, 적은 경우 기존 summary의 요소 크기를 유지하지 못하는 모습이에요.

### After

<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/d9fc4441-4cb1-4c64-af1e-f27719e31913" />
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/e59ca11c-ed1a-4c8a-915b-cd9132563c5d" />

## 🔍 고민 지점

**글자 수에 따른 요약 바텀 시트 크기 변화**

- **문제점**: 
  - 글자 수가에 따라 바텀 시트 크기가 변하는 게 어색하게 다가왔어요.
- **해결 과정**: 
   - 요소의 크기는 사용자가 조작하지 않는 이상 고정적으로 제공해야 하지 않을까 생각했어요. 
  - 그래서 그냥 80vh(h-full)로 뒤에 떠있는 요소를 가려버렸어요.
  - 그런데 핸들을 본격적으로 사용하는 경우(위나 아래로 스크롤) 뒤의 요소들이 드러날 거 같아요.

## 💬 기타 참고 사항

- 여타 다른 compact, image 등 `h-auto`가 적용된 부분을 주의해야 할 것 같아요.
- 설계 방향에 따라 다르겠지만, 내부 요소에 따라 바텀시트가 변한다면, 최대 크기를 정해 커다란 요소 때문에 레이아웃을 벗어나는 상황을 방지해야 할 것 같네요.