### PR TITLE
feat: NCP CLI를 이용한 ACG 설정 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event != 'pull_request'
     runs-on: ubuntu-latest
+
+    env:
+      ACG_RULE_FORMAT: "protocolTypeCode='TCP',ipBlock='GITHUB_IP/32',portRange='22'"
+
     steps:
       - name: Get Github Actions IP
         id: ip
@@ -46,7 +50,7 @@ jobs:
       - name: Add Github Action IP to ACG
         run: |
           cd CLI_*/cli_linux
-          RULE="protocolTypeCode='TCP',ipBlock='${{ steps.ip.outputs.public_ip }}/32',portRange='22'"
+          RULE=$(echo "${{ env.ACG_RULE_FORMAT }}" | sed "s/GITHUB_IP/${{ steps.ip.outputs.public_ip }}/")
           
           ./ncloud vserver addAccessControlGroupInboundRule \
             --regionCode KR \
@@ -62,7 +66,9 @@ jobs:
           password: ${{ secrets.DEV_PASSWORD }}
           script: |
             cd ~/projects/web06-locus
-            git pull origin develop 
+            git fetch origin develop
+            git checkout -f develop
+            git pull origin develop
             echo "${{ secrets.DEV_ENV_PROD }}" > .env.prod
             docker login ${{ secrets.DEV_REGISTRY }} -u ${{ secrets.NCP_ACCESS_KEY }} -p ${{ secrets.NCP_SECRET_KEY }}
             docker compose pull
@@ -70,13 +76,13 @@ jobs:
             docker image prune -f
             docker compose exec -T locus-api pnpm --filter @locus/api run db:push
 
-      - name: Remove Github Action IP from ACG (Post-action)
+      - name: Remove Github Action IP from ACG
         if: always()
         run: |
           sleep 10
 
           cd CLI_*/cli_linux
-          RULE="protocolTypeCode='TCP',ipBlock='${{ steps.ip.outputs.public_ip }}/32',portRange='22'"
+          RULE=$(echo "${{ env.ACG_RULE_FORMAT }}" | sed "s/GITHUB_IP/${{ steps.ip.outputs.public_ip }}/")
           
           ./ncloud vserver removeAccessControlGroupInboundRule \
             --regionCode KR \


### PR DESCRIPTION
## 📌 관련 이슈
#114 

<br>

## ✅ PR 체크리스트(최소요구조건)

[ ] 테스트 작성했다.

## ✨ 작업 개요

- [x] NCP CLI 를 이용한 ACG 규칙 추가 및 제거
- [x] NCP CLI 캐시 설정

## 🧹 작업 상세 내용

1. **NCP CLI 기반 보안 파이프라인 구축**
   - 배포 직전 GitHub Actions의 공인 IP를 가져와 해당 IP만 SSH 접속이 가능하도록 ACG 규칙 자동 추가
   - 배포 완료(성공/실패 무관) 후, 추가했던 규칙 즉시 삭제
   
2. **배포 효율성 개선**
   - `actions/cache`를 활용하여 매 배포마다 반복되는 CLI 다운로드/압축 해제 과정 제거

   <br>

## 📸 스크린샷 (선택)

<img width="1124" height="190" alt="image" src="https://github.com/user-attachments/assets/0431f087-2844-4f10-b756-7e490dde529e" />

## 🔍 고민 지점

**[ 첫 번째 고민: 인프라 반영 지연에 따른 ACG 설정 잠금(Lock) ]**

- **문제점**: SSH 배포 완료 직후 삭제 명령을 날릴 때, NCP API에서 아래와 같은 에러와 함께 규칙 삭제에 실패하는 현상이 있었습니다.
<img width="1122" height="972" alt="image" src="https://github.com/user-attachments/assets/79e07e83-3f93-438a-b0d8-e90f1a514dc2" />

- **해결 과정**: `Remove` 단계 직전에 `sleep 10`을 추가하여 NCP 내부 인프라에 설정이 동기화될 시간을 물리적으로 추가했습니다... 이게 과연 최선의 방법이었을까 싶네요. 여하튼 잘 돌아가긴 합니다. CLI 다운로드 과정 캐싱 덕분에 CD 전체 시간은 (지금까지는...!) 40초대 안으로 들어오고 있어서, sleep 10이 큰 영향을 주지는 않는다고 판단해 이대로 PR을 올립니다. 혹시 다른 더 좋은 방법이 있다면 언제든 피드백 부탁드리겠습니다!!


## 💬 기타 참고 사항

<br>
위 스크린 샷은 포크된 레포에서 진행한 결과를 찍은 사진입니당!