### PR TITLE
[Fix] rabbit MQ volume 설정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,12 +57,15 @@ services:
   locus-rabbitmq:
     image: rabbitmq:4-management
     container_name: locus-rabbitmq
+    hostname: locus-rabbit-node
     ports:
       - '5672:5672'
       - '15672:15672'
     environment:
-      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER}
-      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS}
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_DEFAULT_USER}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_DEFAULT_PASS}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
     networks:
       - locus-network
     restart: always


### PR DESCRIPTION
## 📌 관련 이슈
<img width="738" height="587" alt="image" src="https://github.com/user-attachments/assets/d710e5f7-dca1-42ca-8f6e-16506a09ce33" />

- RabbitMQ 컨테이너 재시작 시 사용자 데이터 및 권한 초기화 문제 해결
- CD 과정에서 RabbitMQ 환경 변수 주입 누락 문제 해결

## ✅ PR 체크리스트(최소요구조건)

[ ] 테스트 작성했다.

## ✨ 작업 개요

- [x] RabbitMQ 데이터 영속성을 위한 Named Volume 적용

- [x] RabbitMQ 호스트 네임 고정

- [x] 환경 변수 주입 방식 개선 (List 형식 적용)

## 🧹 작업 상세 내용

## 📸 스크린샷 (선택)

<br>

## 🔍 고민 지점
<img width="778" height="214" alt="image" src="https://github.com/user-attachments/assets/f1ca3029-074c-4645-856d-af33b45bbe4d" />

- 볼륨을 연결했음에도 데이터 폴더를 찾지 못하는 이슈

- RabbitMQ의 저장소 구조가 rabbit@hostname 폴더 형식을 따른다는 공식 문서를 확인했습니다. 호스트 네임을 고정하지 않으면 매번 랜덤한 이름의 폴더가 생성되어 데이터를 못 읽는 문제를 방지하기 위해 hostname 설정을 추가했습니다.

## 💬 기타 참고 사항

<br>
