### PR TITLE
[Fix] 리프레시 토큰 쿠키의 Path 범위를 루트(/)로 확대

### DIFF
--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -174,7 +174,7 @@ export class AuthController {
       secure: process.env.NODE_ENV === 'production', // 프로덕션 환경(HTTPS)에서만 전송
       sameSite: 'lax',
       maxAge: this.REFRESH_TOKEN_MAX_AGE,
-      path: '/api/auth/reissue', // 오직 재발급 경로에서만 전송
+      path: '/', // 모든 경로에서 쿠키 전송 (API 요청 시 포함되도록)
     });
   }
 
@@ -183,7 +183,7 @@ export class AuthController {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production', // 프로덕션 환경(HTTPS)에서만 전송
       sameSite: 'lax',
-      path: '/api/auth/reissue',
+      path: '/',
     });
   }
 


### PR DESCRIPTION
## 📌 관련 이슈

*  #227
  리프레시 토큰이 유효하지 않은 토큰으로 판단되어 로그인 연장이 실패하는 문제

<br>

## ✅ PR 체크리스트(최소요구조건)

* [ ] 테스트 작성했다. 

<br>

## ✨ 작업 개요

* 리프레시 토큰 쿠키가 재발급 요청 시 누락되던 문제 수정
* 리프레시 토큰 재발급(RTR) 시 토큰 교체 로직 정리
* 로그인 연장 실패로 이어지던 인증 플로우 정상화

<br>

## 🧹 작업 상세 내용

### 1. 리프레시 토큰 쿠키 Path 문제 해결

* 기존에는 리프레시 토큰 쿠키의 `path`가
  `/api/auth/reissue`로 제한되어 있었음
* 이로 인해 **재발급 엔드포인트 외의 요청에서는**
  브라우저가 리프레시 토큰 쿠키를 포함하지 않음
* 결과적으로 서버에서는

  > “리프레시 토큰이 존재하지 않거나 유효하지 않음”
  > 으로 판단하게 되었음

➡️ **쿠키 Path를 `/`로 변경하여**

* 모든 API 요청에서 브라우저가 리프레시 토큰 쿠키를 포함하도록 수정

<br>

## 🔍 문제 흐름 정리 (원인 분석)

### ❌ 기존 흐름

1. 로그인 → 리프레시 토큰 쿠키 발급 (`path=/api/auth/reissue`)
2. 액세스 토큰 만료
3. 로그인 연장 시도
4. 재발급 요청에서 **쿠키가 포함되지 않음**
5. 서버: “유효하지 않은 토큰”
6. 로그인 연장 실패 → 재로그인 강제

### ✅ 수정 후 흐름

1. 로그인 → 리프레시 토큰 쿠키 발급 (`path=/`)
2. 액세스 토큰 만료
3. 재발급 요청 시 리프레시 토큰 쿠키 정상 포함
4. 서버에서 기존 토큰 검증 → 삭제 → 새 토큰 발급
5. 액세스 토큰 재발급 성공
6. 로그인 세션 정상 유지

<br>

## 🔍 고민 지점

### [ 첫 번째 고민 ]

**쿠키 Path 범위를 어디까지 허용할 것인가**

* **문제점**

  * 보안 관점에서는 최소 Path 설정이 안전
  * 하지만 인증 구조상
    재발급 요청 외의 API에서도
    리프레시 토큰이 필요할 수 있음

* **해결 과정**

  * 현재 인증 플로우에서는
    브라우저 단에서 리프레시 토큰이
    안정적으로 전달되는 것이 더 중요하다고 판단
  * 쿠키 Path를 `/`로 확장하여
    인증 실패 가능성을 제거


<br>

## 💬 기타 참고 사항

* ㅈㅔㅂㅏ ㄹ ㄷㅗㅐㄹㅏ