### PR TITLE
[Fix] limit이 100 초과하는 이슈 해결

### DIFF
--- a/apps/web/src/features/home/ui/MapViewport.tsx
+++ b/apps/web/src/features/home/ui/MapViewport.tsx
@@ -96,7 +96,7 @@ export default function MapViewport({
           swLat: fetchBounds.swLat,
           swLng: fetchBounds.swLng,
           page: 1,
-          limit: 500, // 충분히 큰 값으로 설정
+          limit: 100, // 충분히 큰 값으로 설정
           sortOrder: 'desc',
         }
       : null,


### PR DESCRIPTION
- i/o 요청 줄이려고 limit 값 줌 레벨에 따라 크게 줬음
- 서버 api 로직상 ㅣimit 100 이상은 에러가 뜸
- 고로 클라이언트 limit 값 수정함