### PR TITLE
[HOTFIX] TypeScript ESLint unsafe 타입 에러 수정

### DIFF
--- a/apps/web/src/features/record/hooks/useGetRecordDetail.ts
+++ b/apps/web/src/features/record/hooks/useGetRecordDetail.ts
@@ -16,7 +16,7 @@ export function useGetRecordDetail(
 ) {
   return useQuery<RecordDetail, Error>({
     queryKey: ['record', 'detail', publicId],
-    queryFn: async () => {
+    queryFn: async (): Promise<RecordDetail> => {
       if (!publicId) {
         throw new Error('기록 ID가 필요합니다.');
       }

--- a/apps/web/src/features/record/ui/RecordSummaryBottomSheet.tsx
+++ b/apps/web/src/features/record/ui/RecordSummaryBottomSheet.tsx
@@ -9,6 +9,7 @@ import ActionButton from '@/shared/ui/button/ActionButton';
 import { useGetRecordDetail } from '../hooks/useGetRecordDetail';
 import { logger } from '@/shared/utils/logger';
 import LoadingPage from '@/shared/ui/loading/LoadingPage';
+import type { RecordDetail } from '@locus/shared';
 import type {
   RecordSummaryBottomSheetProps,
   RecordSummaryHeaderProps,
@@ -37,7 +38,7 @@ export default function RecordSummaryBottomSheet({
   });
 
   // 타입 단언 (useQuery의 타입 추론 문제 해결)
-  const recordDetail = recordDetailRaw ?? undefined;
+  const recordDetail: RecordDetail | undefined = recordDetailRaw ?? undefined;
 
   // 로딩 상태 처리
   if (isOpen && typeof record === 'string' && isLoading) {
@@ -75,17 +76,24 @@ export default function RecordSummaryBottomSheet({
           tags: record.tags,
           content: record.text,
         }
-      : {
-          title: extractTitle(recordDetail!.title),
-          date: recordDetail!.createdAt,
-          location: {
-            name: recordDetail!.location.name ?? '',
-            address: recordDetail!.location.address ?? '',
-          },
-          // RecordDetail의 tags는 TagDetailResponseSchema[] 형태이므로 name을 추출
-          tags: recordDetail!.tags?.map((tag) => tag.name),
-          content: recordDetail!.content ?? '',
-        };
+      : recordDetail
+        ? {
+            title: extractTitle(recordDetail.title),
+            date: recordDetail.createdAt,
+            location: {
+              name: recordDetail.location.name ?? '',
+              address: recordDetail.location.address ?? '',
+            },
+            tags: recordDetail.tags?.map((tag) => tag.name) ?? [],
+            content: recordDetail.content ?? '',
+          }
+        : {
+            title: '',
+            date: new Date(),
+            location: { name: '', address: '' },
+            tags: [],
+            content: '',
+          };
 
   return (
     <BaseBottomSheet isOpen={isOpen} onClose={onClose} height="summary">

--- a/apps/web/src/features/record/ui/RecordWritePage.tsx
+++ b/apps/web/src/features/record/ui/RecordWritePage.tsx
@@ -135,7 +135,7 @@ export default function RecordWritePage({
       const record: Record = {
         id: response.publicId,
         text: response.title,
-        tags: response.tags.map((tag) => tag.name),
+        tags: (response.tags ?? []).map((tag) => tag.name),
         location: {
           name: response.location.name ?? initialLocation.name,
           address: response.location.address ?? initialLocation.address,

--- a/apps/web/src/infra/api/services/recordService.ts
+++ b/apps/web/src/infra/api/services/recordService.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import { apiClient } from '../apiClient';
 import { API_ENDPOINTS } from '../constants';
 import {
@@ -103,7 +104,9 @@ export async function getRecordDetail(publicId: string): Promise<RecordDetail> {
     );
 
     // 2. Response 검증 + data 추출
-    const validated = validateApiResponse(RecordDetailResponseSchema, response);
+    const validated = validateApiResponse<
+      z.infer<typeof RecordDetailResponseSchema>
+    >(RecordDetailResponseSchema, response);
 
     logger.info('기록 상세 조회 성공', { publicId });
     return validated.data;

--- a/apps/web/src/router/index.tsx
+++ b/apps/web/src/router/index.tsx
@@ -16,6 +16,7 @@ import { useDeleteRecord } from '@/features/record/hooks/useDeleteRecord';
 import { useGetRecordDetail } from '@/features/record/hooks/useGetRecordDetail';
 import { useRecordGraph } from '@/features/connection/hooks/useRecordGraph';
 import { logger } from '@/shared/utils/logger';
+import type { RecordDetail } from '@locus/shared';
 
 // 라우트별 지연 로딩
 const OAuthLoginPage = lazy(() => import('@/features/auth/ui/OAuthLoginPage'));
@@ -103,7 +104,7 @@ function RecordDetailPageRoute() {
   }
 
   // 타입 단언 (useQuery의 타입 추론 문제 해결)
-  const detail = recordDetail;
+  const detail: RecordDetail = recordDetail;
 
   // 연결 개수 계산 (그래프 API의 edges에서 계산)
   const connectionCount =
@@ -129,7 +130,7 @@ function RecordDetailPageRoute() {
       : undefined;
 
   // 태그를 문자열 배열로 변환 (기존 타입 호환)
-  const tags = detail.tags?.map((tag) => tag.name);
+  const tags = (detail.tags ?? []).map((tag) => tag.name);
 
   const recordProps = {
     title: detail.title,
@@ -302,7 +303,7 @@ function ConnectionManagementPageRoute() {
           address: recordDetail.location.address ?? '',
         },
         date: new Date(recordDetail.createdAt),
-        tags: recordDetail.tags?.map((tag) => tag.name) ?? [],
+        tags: (recordDetail.tags ?? []).map((tag) => tag.name),
         connectionCount: connectedRecordIds.length,
       }
     : {


### PR DESCRIPTION
- useGetRecordDetail hook의 queryFn 반환 타입 명시
- RecordSummaryBottomSheet, RecordWritePage, router/index.tsx에서 RecordDetail 타입 단언 추가
- recordService.ts의 validateApiResponse 호출 시 제네릭 타입 명시
- tags 배열 처리 시 null 체크 추가