### PR TITLE
[Fix] 알림이 가지 않는 문제 해결을 위한 앱 타임존 설정 추가 

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,8 +9,8 @@ import { ValidationException } from './common/exceptions/validation.exception';
 import { ValidationError } from 'class-validator';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
   process.env.TZ = 'Asia/Seoul';
+  const app = await NestFactory.create(AppModule);
 
   app.setGlobalPrefix('api');
 


### PR DESCRIPTION
## 📌 관련 이슈

<br>

## ✅ PR 체크리스트(최소요구조건)


## ✨ 작업 개요

- [x] 타임존 asia/seoul 설정
      

## 🧹 작업 상세 내용

현재 NCP에서 동작하는 서버가 UTC 기준으로 동작을 해서 서버 시간이 새벽일 경우 제대로 알림 스케줄러가 동작하지 않아서 앱 타임존을 변경했어요.

## 📸 스크린샷 (선택)

<br>

## 🔍 고민 지점

이래도 되겟쬬..?

## 💬 기타 참고 사항

<br>
